### PR TITLE
fix: don't set busy signal if no provider is available

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -89,15 +89,15 @@ export default {
       return this.setStatus("noEditor");
     }
 
-    const target = editor.getFileName();
-    this.busySignalProvider &&
-      this.busySignalProvider.add(`Outline: ${target}`);
-
     const provider = this.outlineProviderRegistry.getProvider(editor);
 
     if (!provider) {
       return this.setStatus("noProvider");
     }
+
+    const target = editor.getFileName();
+    this.busySignalProvider &&
+      this.busySignalProvider.add(`Outline: ${target}`);
 
     const outline = await provider.getOutline(editor);
 


### PR DESCRIPTION
Currently the status of `atom-ide-outline` will always be busy if the no supported language server is available. This PR fixes it by only setting a busy signal if a provider was found.