### PR TITLE
fix: entry with missing icon breaking outline generation

### DIFF
--- a/lib/outlineView.js
+++ b/lib/outlineView.js
@@ -106,10 +106,12 @@ function getIcon(iconType) {
   // atom-languageclient mapping: https://github.com/atom/atom-languageclient/blob/485bb9d706b422456640c9070eee456ef2cf09c0/lib/adapters/outline-view-adapter.ts#L270
 
   const iconElement = document.createElement("span");
-  iconElement.className = `icon ${iconType}`;
+  const hasIconType = typeof iconType === "string" && iconType.length > 0;
 
-  const type = iconType.replace("type-", "");
-  const iconSymbol = type.substring(0, 1);
+  iconElement.className = hasIconType ? `icon ${iconType}` : "icon";
+
+  const type = hasIconType && iconType.replace("type-", "");
+  const iconSymbol = type ? type.substring(0, 1) : "?";
   iconElement.innerHTML = `<span>${iconSymbol}</span>`;
 
   return iconElement;

--- a/spec/outline-view-spec.js
+++ b/spec/outline-view-spec.js
@@ -45,7 +45,7 @@ describe("Outline view", () => {
       );
 
       expect(outlineViewElement.children.length > 0).toEqual(true);
-      expect(rootRecords.length).toEqual(2);
+      expect(rootRecords.length).toEqual(3);
     });
   });
 
@@ -86,6 +86,23 @@ describe("Outline view", () => {
 
       expect(recordContentHolder.textContent).toEqual("fprimaryFunction");
       expect(recordIcon.textContent).toEqual("f");
+    });
+  });
+
+  it("provides fallback for entries without icon", () => {
+    atom.commands.dispatch(workspaceElement, "outline:toggle");
+
+    const editor = new TextEditor();
+    waitsForPromise(() => OutlinePackage.getOutline(editor));
+
+    runs(() => {
+      const recordContentHolder = workspaceElement.querySelector(
+        ".outline-view li:nth-child(3) span"
+      );
+      const recordIcon =
+        recordContentHolder && recordContentHolder.querySelector(".icon");
+
+      expect(recordIcon.textContent).toEqual("?");
     });
   });
 

--- a/spec/outlineMock.json
+++ b/spec/outlineMock.json
@@ -46,6 +46,24 @@
           "value": "scondaryFunction"
         }
       ]
+    },
+    {
+      "children": [],
+      "endPosition": {
+        "column": 19,
+        "row": 8
+      },
+      "representativeName": "primaryFunction",
+      "startPosition": {
+        "column": 13,
+        "row": 6
+      },
+      "tokenizedText": [
+        {
+          "kind": "method",
+          "value": "primaryFunction"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds fallback icon (`?` as unknown), fixing outline generation breaking when symbol with missing icon info is present in a tree