### PR TITLE
remove excess less

### DIFF
--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -6,11 +6,6 @@
 @import "syntax-variables";
 
 .outline-view {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
-
   overflow-y: auto;
 
   font-size: 1rem;

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -7,7 +7,7 @@
 
 .outline-view {
   overflow-y: auto;
-  
+
   ul {
     list-style-type: none;
     padding: 0;
@@ -26,7 +26,6 @@
 
   .icon {
     display: inline-block;
-    height: 100%;
     width: 20px;
     text-align: center;
     font-weight: bold;

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -7,10 +7,7 @@
 
 .outline-view {
   overflow-y: auto;
-
-  font-size: 1rem;
-  font-family: @font-family;
-
+  
   ul {
     list-style-type: none;
     padding: 0;


### PR DESCRIPTION
Using `display: flex;` and `flex-direction: column;` do not make sense when it has a unique element as a child (the `ul`), so removing those rules does not breaks the component's styles, and as Atom's styles set the panes to an absolute position and `top`, `right`, `bottom` and `left` to `0` it takes all the width and height. That let's remove the `width` and `height` rules.

For the `font` rules there are no side-effects if we remove them. Using `rem` will take the value from the `html` element and the `font-family` it's defined by Atom in the `atom-workspace` element, so is the user who has to update those values in its own stylesheet file.

The rule  `height: 100%` for the selector `.icon` does not work as its parent does not have height and by default uses `auto`. it only can work setting a height to its a parent or using a different unit as `px`.

@abaracedo 