### PR TITLE
Add icon to view tab

### DIFF
--- a/src/outlineView.ts
+++ b/src/outlineView.ts
@@ -23,6 +23,10 @@ export class OutlineView {
     return "Outline"
   }
 
+  getIconName() {
+    return 'list-unordered';
+  }
+
   setOutline({ tree: outlineTree, editor }: { tree: OutlineTree; editor: TextEditor }) {
     const outlineViewElement = this.getElement()
     outlineViewElement.innerHTML = ""

--- a/src/outlineView.ts
+++ b/src/outlineView.ts
@@ -24,7 +24,7 @@ export class OutlineView {
   }
 
   getIconName() {
-    return 'list-unordered';
+    return "list-unordered"
   }
 
   setOutline({ tree: outlineTree, editor }: { tree: OutlineTree; editor: TextEditor }) {


### PR DESCRIPTION
This pull request adds an `unordered-list` icon to the tab of the `OutlineView` panel, improving the consistency of its design with other side panel tabs.