### PR TITLE
Debounce updates to prevent any performance impact 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   },
   "atomTestRunner": "./spec/runner",
   "dependencies": {
-    "atom-ide-base": "^1.6.1"
+    "atom-ide-base": "^1.6.1",
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@types/atom": "latest",
     "@types/node": "^14.0.27",
+    "@types/lodash": "^4.14.162",
     "typescript": "^3.9.7",
     "tslib": "^2.0.1",
     "@types/jasmine": "^3.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,12 @@
 dependencies:
   atom-ide-base: 1.6.1
+  lodash: 4.17.20
 devDependencies:
   '@babel/cli': 7.10.5_@babel+core@7.11.1
   '@babel/core': 7.11.1
   '@types/atom': 1.40.4
   '@types/jasmine': 3.5.12
+  '@types/lodash': 4.14.162
   '@types/node': 14.0.27
   atom-jasmine3-test-runner: 5.0.5
   babel-preset-atomic: 0.1.0_85545ff2d5eda21cd5151f447bb4f089
@@ -1537,6 +1539,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+  /@types/lodash/4.14.162:
+    dev: true
+    resolution:
+      integrity: sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==
   /@types/node/14.0.24:
     dev: true
     resolution:
@@ -4672,6 +4678,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+  /lodash/4.17.20:
+    dev: false
+    resolution:
+      integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
   /loose-envify/1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -6958,6 +6968,7 @@ specifiers:
   '@babel/core': 7.11.1
   '@types/atom': latest
   '@types/jasmine': ^3.5.12
+  '@types/lodash': ^4.14.162
   '@types/node': ^14.0.27
   atom-ide-base: ^1.6.1
   atom-jasmine3-test-runner: ^5.0.5
@@ -6966,6 +6977,7 @@ specifiers:
   cross-env: latest
   eslint: 7.6.0
   eslint-config-atomic: ^1.3.0
+  lodash: ^4.17.20
   npm-check-updates: latest
   prettier: ^2.0.5
   rollup: ^2.23.1


### PR DESCRIPTION
This adds an option to wait for new changes before updating the outline. A high number will improve the responsiveness of the text editor.

This is added to prevent the outline from slowing down the text editor in large files. Because a hard real-time outline update is not needed in normal cases and the difference is not noticeable for the human eyes.